### PR TITLE
Update airlines CAL TTW SJX country to TAIWAN

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -5,5 +5,12 @@
     "callsign": "SIBERIAN AIRLINES",
     "country": "RUSSIAN FEDERATION",
     "virtual": false
+  },
+  {
+    "icao": "CAL",
+    "name": "CHINA AIRLINES",
+    "callsign": "DYNASTY",
+    "country": "TAIWAN",
+    "virtual": false
   }
 ]

--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -12,5 +12,26 @@
     "callsign": "DYNASTY",
     "country": "TAIWAN",
     "virtual": false
+  },
+  {
+    "icao": "MDA",
+    "name": "MANDARIN AIRLINES",
+    "callsign": "MANDARIN",
+    "country": "TAIWAN",
+    "virtual": false
+  },
+  {
+    "icao": "SJX",
+    "name": "STARLUX AIRLINES CO., LTD",
+    "callsign": "STARWALKER",
+    "country": "TAIWAN",
+    "virtual": false
+  },
+  {
+    "icao": "TTW",
+    "name": "TIGERAIR TAIWAN CO. LD.",
+    "callsign": "SMART CAT",
+    "country": "TAIWAN",
+    "virtual": false
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1654972

### 🔗 Linked Issue

NA

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [X ] ✈️ Airline Changes
- [ ] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description
Due to the history of China Airline they have been created in ROC Republic of China is Taiwan not China
 
CAL wiki: https://en.wikipedia.org/wiki/China_Airlines
SJX wiki: https://en.wikipedia.org/wiki/Starlux_Airlines
TTW wiki: https://en.wikipedia.org/wiki/Tigerair_Taiwan