### PR TITLE
Added Muenchen-Airways, Sunrise and Muenchen AirCargo

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -19,12 +19,5 @@
     "callsign":"SUNRISE",
     "country":"GERMANY",
     "virtual":true
-  },
-  {
-    "icao":"MCA",
-    "name":"MUENCHEN AIRCARGO",
-    "callsign":"MUENCHEN AIRCARGO",
-    "country":"GERMANY",
-    "virtual":true
   }
 ]

--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -5,5 +5,26 @@
     "callsign": "SIBERIAN AIRLINES",
     "country": "RUSSIAN FEDERATION",
     "virtual": false
+  },
+  {
+    "icao":"MUC",
+    "name":"MUENCHEN AIRWAYS",
+    "callsign":"MUENCHEN AIRWAYS",
+    "country":"GERMANY",
+    "virtual":true
+  },
+  {
+    "icao":"SUN",
+    "name":"SUNRISE",
+    "callsign":"SUNRISE",
+    "country":"GERMANY",
+    "virtual":true
+  },
+  {
+    "icao":"MCA",
+    "name":"MUENCHEN AIRCARGO",
+    "callsign":"MUENCHEN AIRCARGO",
+    "country":"GERMANY",
+    "virtual":true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1421253

### 🔗 Linked Issue

n.a.

### ❓ Type of change

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Added Muenchen Airways, Sunrise and Muenchen AirCrago as virtual airlines.
