### PR TITLE
Add Emirates Virtual to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -134,7 +134,7 @@
   {
     "icao": "UAE",
     "name": "Emirates Virtual",
-    "callsign:" "EMIRATES",
+    "callsign": "EMIRATES",
     "virtual": true
   }
 ]

--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -130,5 +130,11 @@
     "name": "Air Württemberg",
     "callsign": "EMBERG",
     "virtual": true
+  },
+  {
+    "icao": "UAE",
+    "name": "Emirates Virtual",
+    "callsign:" "EMIRATES",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
Add Emirates Virtual to VR Custom Data so it can be shown as a VA on VATSIM Radar

### 🔗 Your VATSIM ID

1528029

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [x] ✈️ Airline Changes
- [ ] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

<!-- Tell us more about your PR -->

This PR adds Emirates Virtual (https://ek-virtual.com/) to VR Custom Data so UAE flights can be shown as a VA on VATSIM Radar.
