### PR TITLE
Added Jakauma Airlines

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -130,5 +130,11 @@
     "name": "Air Württemberg",
     "callsign": "EMBERG",
     "virtual": true
+  },
+  {
+    "icao": "CDF",
+    "name": "Jakauma Airlines",
+    "callsign": "FUNCTION",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1465205

### ❓ Type of change

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Added Jakauma Airlines (ICAO: CDF, callsign: Function) to the custom database. [Jakauma Airlines](https://newsky.app/airline/cdf) was founded in March 2024 on Newsky.