### PR TITLE
Add Lun'Air Virtual Airline

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -274,5 +274,11 @@
     "name": "Willow Airlines",
     "callsign": "Willow",
     "virtual": true
+  },
+  {
+    "icao": "LNR",
+    "name": "Lun'Air VA",
+    "callsign": "Lun'Air",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1632233

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

This PR adds Lun'Air Virtual Airline to the `airlines.json`.
Website: https://lunair.fr/

