### PR TITLE
Add HEC virtual airline

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -334,5 +334,11 @@
     "name": "American Virtual",
     "callsign": "American",
     "virtual": true
+  },
+  {
+    "icao": "HEC",
+    "name": "Hermann Cargo",
+    "callsign": "Hermann Cargo",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1568055

### 🔗 Linked Issue

Resolves #123 

### ❓ Type of change

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Add Hermann Cargo with ICAO HEC
