### PR TITLE
Update airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -389,9 +389,9 @@
     "callsign": "Hermann Cargo",
     "virtual": true
   },
-    {
+  {
     "icao": "FRS",
-    "name": "Friesenflieger",
+    "name": "FriesenFlieger",
     "callsign": "Friese",
     "virtual": true
   }

--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -388,5 +388,11 @@
     "name": "Hermann Cargo",
     "callsign": "Hermann Cargo",
     "virtual": true
+  },
+    {
+    "icao": "FRS",
+    "name": "Friesenflieger",
+    "callsign": "Friese",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
added Friesenflieger virtual airline

### 🔗 Your VATSIM ID

1746912

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Friesenflieger are a VFR based virtual airline, flying mainly in Germany, Austria and Switzerland. I had a [conversation on discord](https://discord.com/channels/1223649894191992914/1223649894191992917/1384169217225396386) about adding Friesenflieger instead of the real callsign for "Comfort Servicos" in Spain, which took "our" callsign after our virtual airline already exists. 

I asked Leon K, 1424877 who is responsible for GNG in Germany to add Friesenflieger. He told me that it was already included for a very long time. Unfortunately I cannot view inside since its only for Vatsim officials. But he told me I could incorporate it here:

> FRS wird in allen unseren Paketen als "Friese" Callsign angezeigt. Wenn ihr die Änderung auf VATSIM Radar haben wollt, dann müsst ihr euch an die Entwickler dessen wenden.
> Wir haben nur Kontrolle über unsere eigenen Pakete. Vatsim Radar nutzt aber nicht unser Paket.
> siehe: [Github Vatsim Radar](https://github.com/VATSIM-Radar/vatsim-radar/blob/394dbdcadb85687612714607a55bcd328fdf1c56/docs/contributing/airlines.md?plain=1)
