### PR TITLE
 airlines.json - Added Virtual airline Cruizing Air

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -388,5 +388,11 @@
     "name": "Hermann Cargo",
     "callsign": "Hermann Cargo",
     "virtual": true
+  },
+    {
+    "icao": "CZN",
+    "name": "Cruizing Air",
+    "callsign": "Cruizing",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
Added Virtual airline Cruizing Air

### 🔗 Your VATSIM ID

 CID --> 1773586

### 🔗 Linked Issue


### ❓ Type of change
New Virtual Airline added


- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description
At Cruizing Air, we believe in making your virtual flying experience unforgettable. Based in the vibrant city of Brisbane, Queensland, we offer a wide range of routes and destinations to explore within the mesmerizing world of Microsoft Flight Simulator. 

<!-- Tell us more about your PR -->
Added my Virtual Airline Cruizing Air to vatsim radar data, would love to see this added

