### PR TITLE
Addition of Paramount Airways

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1,4 +1,10 @@
 [
+   {
+    "icao": "PRU",
+    "name": "Paramount Airways",
+    "callsign": "Paramount",
+    "virtual": true
+  },
   {
     "icao": "CWG",
     "name": "Chickenwings Virtual Airline",


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1868137

### 🔗 Linked Issue

Addition of a New Virtual Airline.

### ❓ Type of change

- [ ] 🆕 New Airline

### 📚 VA Website

https://paramountairways.net/

<img width="1385" height="664" alt="image" src="https://github.com/user-attachments/assets/33503067-d2aa-48f2-8e30-293653bb29ce" />


### 📚 Description

This pull request updates vatsim radar to show the new paramount airways virtual airline. 

