### PR TITLE
Add Virtuelle Airline inter-wings

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1151,4 +1151,8 @@
     "callsign": "ALLIED",
     "virtual": true
   }  
-]
+    "icao": "ITW",
+    "name": "inter - wings",
+    "callsign": "INTERWINGS",
+    "virtual": true
+  },


### PR DESCRIPTION
Dear Sir or Madam, I have added our airline, the inter-wings, because it is not displayed correctly in the vatsim radar. We are also certified at vatsim.

### 🔗 Your VATSIM ID
1651523
<!-- Please specify your CID -->

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change
We are displayed incorrectly in the Vatsim Radar and we are not displayed as a Verified Virtual Airline
<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [x ] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website
https://inter-wings.de/
Please refer your VA Website(s) - ideally, with some proof that you belong to it. 
https://inter-wings.de/pilotenliste/ ( Rene) 
### 📚 Description

<!-- Tell us more about your PR -->

