### PR TITLE
Add Polaris Airlines to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1152,7 +1152,7 @@
     "virtual": true
   }  
    {
-    "icao": "PLI",
+    "icao": "PLX",
     "name": "Polaris Airlines",
     "callsign": "Northern Sky",
     "virtual": true


### PR DESCRIPTION
### 🔗 1171432

<!-- Please specify your CID --> 
1171432

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [ X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website 

https://flypolarisairlines.com/

Please refer your VA Website(s) - ideally, with some proof that you belong to it.  

Name of the CEO and COO are located on the About me page of the airline website 
CEO Founder: Sidoine Vedeau

name on roster available or in the Operations manual

### 📚 Description

<!-- Tell us more about your PR --> 





Created a new VA and would like it to show on VATRADAR we have been approved to be a partner airline on VATSIM. We see that PLX our official ICAO is taken but not by a VA or a real airline if possible to replace PLX to our airline? if not PLI would be our ICAO code. 

contact: sidoine.vedeau@gmx.de

