### PR TITLE
Update PolarisAirlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1177,7 +1177,7 @@
     "virtual": true
   },
   {
-    "icao": "PLX",
+    "icao": "PLI",
     "name": "Polaris Airlines",
     "callsign": "NORTHERN SKY",
     "virtual": true


### PR DESCRIPTION
🔗 1171432
1171432

🔗 Linked Issue
❓ Type of change
[ X]✈️ Airline Changes
 🆕 New Airline
🧹 Technical change (refactoring, updates and other improvements) 📚 VA Website
https://flypolarisairlines.com/

Please refer your VA Website(s) - ideally, with some proof that you belong to it.

Name of the CEO and COO are located on the About me page of the airline website CEO Founder: Sidoine Vedeau

name on roster available or in the Operations manual

📚 Description 

Please update our callsign to PLI instead of PLX as it is interfering with another airline. PLX Poolex Airlines doesnt seem to be a real nor a virtual airline on vatsim or the real world. If possibel to remove this inactive airline to be able to use PLX ICAO. If not please modify the ICAO to PLI thank you


