### PR TITLE
Update PolarisAirlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1177,7 +1177,7 @@
     "virtual": true
   },
   {
-    "icao": "PLX",
+    "icao": "PLD",
     "name": "Polaris Airlines",
     "callsign": "NORTHERN SKY",
     "virtual": true


### PR DESCRIPTION
🔗 1171432
1171432

🔗 Linked Issue
❓ Type of change
[ X]✈️ Airline Changes
 🆕 New Airline
🧹 Technical change (refactoring, updates and other improvements) 📚 VA Website
https://flypolarisairlines.com/

Please refer your VA Website(s) - ideally, with some proof that you belong to it.

Name of the CEO and COO are located on the About me page of the airline website CEO Founder: Sidoine Vedeau

name on roster available or in the Operations manual

📚 Description

Please modify our airlines ICAO code to PLD as PLX has been taken by poolex aviation. This airline though does not seem to be a VA on vatsim or a real airline. If possible to remove the airline from the system and replace it by PLX would be appreciated or else replace with PLD. Thank you!


