### PR TITLE
Update airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1235,5 +1235,29 @@
     "name": "Air Mauritius Virtual",
     "callsign": "Air Mauritius",
     "virtual": true
-  }
+  },
+   {
+    "icao": "VTI",
+    "name": "TATA SIA Airlines",
+    "callsign": "VISTARA",
+    "virtual": true
+  },
+   {
+    "icao": "ICE",
+    "name": "Icelandair Group",
+    "callsign": "ICEAIR",
+    "virtual": true
+  },
+   {
+    "icao": "JAI",
+    "name": "Jet Airways",
+    "callsign": "JAI",
+    "virtual": true
+  },
+   {
+    "icao": "KFR",
+    "name": "Kingfisher Airlines",
+    "callsign": "KFR",
+    "virtual": true
+  },
 ]


### PR DESCRIPTION
Added airlines either not in the JSON or historically were around and are no longer there.

### 🔗 Your VATSIM ID 

1876057

### 🔗 Linked Issue

<N/A>

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [-] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

www.goldenageaviation.org

### 📚 Description

We operate a virtual airline called Golden Age Aviation which includes the added airlines, so we want to add this to VATSIM Radar so people can see the link to our VA. I have checked, these airlines/callsigns/ICAOs are not in the data base yet. 

