### PR TITLE
Add virtual airlines to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1494,7 +1494,7 @@
     "name": "Kingfisher Airlines",
     "callsign": "KFR",
     "virtual": true
-  }
+  },
   {
     "icao": "SAS",
     "name": "vSAS - virtual Scandinavian Airlines",


### PR DESCRIPTION
Added multiple virtual airlines including vSAS and vNorwegian.

### 🔗 Your VATSIM ID
1480612

<!-- Please specify your CID -->

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website
vSAS - virtual Scandinavian Airlines: https://flysasvirtual.net/
vNorwegian: https://vnorwegian.com/

Please refer your VA Website(s) - ideally, with some proof that you belong to it. 
Both virtual airlines are owned by me (Andy Prismatic). If further proof is required, you can visit both websites, go to the official Discord, and send me a DM (#prism2k13).

### 📚 Description

<!-- Tell us more about your PR -->

