### PR TITLE
Add Virtual Asiana Airlines to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -348,6 +348,12 @@
     "virtual": true
   },
   {
+    "icao": "AAR",
+    "name": "Virtual Asiana Airlines",
+    "callsign": "Asiana",
+    "virtual": true
+  },
+  {
     "icao": "AAL",
     "name": "American Virtual",
     "callsign": "American",


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1424108

### 🔗 Linked Issue

N/A

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

Please refer your VA Website(s) - ideally, with some proof that you belong to it. 
https://vaarconnect.veeone.cc/

### 📚 Description

Adding a new airline on VATSIM Radar for the Virtual Asiana Airlines

