### PR TITLE
Add Jet Executive airline data to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1237,7 +1237,7 @@
     "virtual": true
   },
   {
-    "icao": "JEX",
+    "icao": "XTV",
     "name": "Jet Executive",
     "callsign": "CHAMPAGNE",
     "virtual": true


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1786018

### 🔗 Linked Issue

N/A

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://jetexecvirtual.com

See my [FsHub profile](https://fshub.io/pilot/27743/profile). I'm the owner of the [Jet Executive FsHub airline](https://fshub.io/airline/JEX/overview).

### 📚 Description

We're a new flying group (not yet a VA due to VATSIM requirements), so we don't yet have 'VA status' but we would love to have a presence on VATSIM Radar!

