### PR TITLE
Add EXU Executive airlines virtual to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -126,6 +126,12 @@
     "virtual": true
   },
   {
+    "icao": "EXU",
+    "name": "EXECUTIVE AIRLINES VIRTUAL",
+    "callsign": "SACIR",
+    "virtual": true
+  },
+  {
     "icao": "WTB",
     "name": "Air Wuerttemberg",
     "callsign": "EMBERG",


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1137529

### 🔗 Linked Issue

N/A

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://executive-airlinesva.es
Proof: https://executive-airlinesva.es/pilots

### 📚 Description

Add EXECUTIVE AIRLINES VIRTUAL with ICAO code EXU and callsign SACIR to the custom airlines list.

