### PR TITLE
Addition of Coastal Airways VA

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -6,6 +6,12 @@
     "virtual": true
   },
   {
+    "icao": "CST",
+    "name": "Coastal Airways",
+    "callsign": "Riptide",
+    "virtual": true
+  },
+  {
     "icao": "PRU",
     "name": "Paramount Airways",
     "callsign": "Paramount",


### PR DESCRIPTION
### 🔗 Your VATSIM ID

950075

### 🔗 Linked Issue

Closes Coastal Airways VA Addition #333 issue

### ❓ Type of change

Adding Coastal Airways Virtual Airline

- [ ] ✈️ Airline Changes
- [X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://vms.flycoastalairways.com/

### 📚 Description

Added Coastal Airways Virtual Airline to the pull request

