### PR TITLE
Update airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -6,6 +6,12 @@
     "virtual": true
   },
   {
+    "icao": "APA",
+    "name": "Airway Philippines",
+    "callsign": "Airway",
+    "virtual": true
+  },
+  {
     "icao": "PRU",
     "name": "Paramount Airways",
     "callsign": "Paramount",
@@ -1234,12 +1240,6 @@
     "icao": "MAU",
     "name": "Air Mauritius Virtual",
     "callsign": "Air Mauritius",
-    "virtual": true
-  },
-  {
-    "icao": "APA",
-    "name": "Airway Philippines",
-    "callsign": "Airway",
     "virtual": true
   }
 ]


### PR DESCRIPTION
Added Airway Philippines

### 🔗
1804191

<!-- Please specify your CID -->

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change
Added a virtual airline that is partnered with vatsim
<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [Airway Philippines ] ✈️ Airline Changes
- [ Virtual Airlines] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website
www.airwayphilippines.com
Please refer your VA Website(s) - ideally, with some proof that you belong to it. 

### 📚 Description
Added virtual airlines from vatsim 

Airline: Airway Philippines
ICAO: APA
Callsign: Airway 
Country: RPLL 

Member here: APA015
<!-- Tell us more about your PR -->

