### PR TITLE
Add European Cargo Virtual airline data

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1235,5 +1235,11 @@
     "name": "Air Mauritius Virtual",
     "callsign": "Air Mauritius",
     "virtual": true
+  },
+  {
+    "icao": "URO",
+    "name": "European Cargo Virtual",
+    "callsign": "EURO",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1329382

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://vamsys.io/register/europeancargovirtual
https://vamsys.io/login/europeancargovirtual 

### 📚 Description

Addition of new VA: vURO | European Cargo Virtual
Proof attached
![Capture d’écran 2025-12-21 153726](https://github.com/user-attachments/assets/267266f8-bf7a-457d-9347-f14c8a0c2029)


