### PR TITLE
Add virtual airlines to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -4,16 +4,19 @@
     "name": "vOCN",
     "callsign": "Ocean",
     "virtual": true
+  },
   {
     "icao": "THY",
     "name": "vTHY",
     "callsign": "Turkish",
     "virtual": true
+  },
   {
     "icao": "VIR",
     "name": "VRGN Virtual",
     "callsign": "Virgin",
     "virtual": true
+  },
   {
     "icao": "EWG",
     "name": "vEWG",


### PR DESCRIPTION
Added new virtual airlines with their ICAO codes and names.

### 🔗 Your VATSIM ID

1274107

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [ X ] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://www.vthy.eu/
https://virtualocn.de/
https://mynextairline.com/airlines/vrgn-virtual

### 📚 Description

vTHY

vTHY (Turkish Airlines Virtual) is a professional virtual airline inspired by Turkish Airlines, offering realistic operations, global routes via Istanbul, structured pilot ranks, and an active flight-sim community on vAMSYS, VATSIM & IVAO. ✈️

vOCN

vOCN (Virtual Discover Airlines) is a modern virtual airline inspired by Discover Airlines, focusing on leisure and long-haul operations from Frankfurt and Munich, featuring realistic routes, structured pilot progression, and an active flight-simulation community on vAMSYS, VATSIM & IVAO. ✈️

VRGN Virtual

VRGN Virtual (Virgin Virtual) is a premium virtual airline inspired by Virgin Atlantic, specializing in long-haul and transatlantic operations from the UK, with realistic routes, modern fleet operations, and a highly active flight-simulation community on vAMSYS, VATSIM & IVAO. ✈️

VRGN does currently not have an actual website.
