### PR TITLE
Add vKQA to Airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1238,19 +1238,19 @@
   },
   {
     "icao": "KQA",
-    "name": "Virtual Kenya Airways",
+    "name": "Virtual Kenya Airways (Kenya Airways)",
     "callsign": "KENYA",
     "virtual": true
   },
   {
     "icao": "JMA",
-    "name": "Virtual Kenya Airways",
+    "name": "Virtual Kenya Airways (Jambojet)",
     "callsign": "CHUI",
     "virtual": true
   },
   {
     "icao": "PRF",
-    "name": "Virtual Kenya Airways",
+    "name": "Virtual Kenya Airways (Precision Air)",
     "callsign": "PRECISION AIR",
     "virtual": true
   }


### PR DESCRIPTION
### 🔗 Your VATSIM ID
1439732

### 🔗 Linked Issue
n/a

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [ ] 🆕 New Airline
- [x] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website
https://vamsys.io/register/vkqa (KQA0002)

### 📚 Description
Adds all the relevant airlines linked to vKQA (Kenya Airways, Jambojet and Precision Air) to show up as vKQA when flying on VATSIM.

