### PR TITLE
Add Axiom Vertical Lift and Axiom Europe

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1669,4 +1669,16 @@
     "callsign": "AXIOM",
     "virtual": true
   }
+  {
+    "icao": "AVT",
+    "name": "Axiom Vertical Lift",
+    "callsign": "AXIOM LIFT",
+    "virtual": true
+  }
+  {
+    "icao": "XIO",
+    "name": "Axiom Europe",
+    "callsign": "AXIOM",
+    "virtual": true
+  }
 ]


### PR DESCRIPTION
Added entries for Axiom's Vertical Lift and European divisions.

### 🔗 Your VATSIM ID

1452308

### 🔗 Linked Issue

N/A

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://axiomjetva.netlify.app

### 📚 Description

Added entries for Axiom Vertical Lift, and Axiom Europe.

