### PR TITLE
Add AIRSKY airline entry to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -4,6 +4,7 @@
    "name": "AIRSKY",  
    "callsign": "AIRSKY",
    "virtual": true
+  },
   {
     "icao": "OCN",
     "name": "vOCN",

--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1,5 +1,10 @@
 [
   {
+   "icao": "ASK",
+   "name": "AIRSKY",  
+   "callsign": "AIRSKY",
+   "virtual": true
+  {
     "icao": "OCN",
     "name": "vOCN",
     "callsign": "Ocean",


### PR DESCRIPTION
Add AIRSKY virtual airline with (ICAO: ASK) to airlines.json

### 🔗 Your VATSIM ID

1908626

### 🔗 Linked Issue

At the moment, ICAO: ASK is associated with the airline Aero Sky S.I. and the callsign MULTISKY.

### ❓ Type of change

- [ ] ✈️ Airline Changes
- [x ] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://vamsys.io/login/airsky
Official Website is coming soon!

### 📚 Description

Add AIRSKY Virtual to the Airline list.

<img width="583" height="185" alt="566287118-0c4a63c0-1120-4bf9-8741-8c60806f21fd" src="https://github.com/user-attachments/assets/bcc981d2-b60b-4964-8a4e-7a4a0d1460e6" />
