### PR TITLE
Add virtual airlines to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1,5 +1,17 @@
 [
   {
+    "icao": "AUA",
+    "name": "Austrian Virtual",
+    "callsign": "Austrian",
+    "virtual": true
+  },
+  {
+    "icao": "SWR",
+    "name": "Swiss Virtual",
+    "callsign": "Swiss",
+    "virtual": true
+  },
+  {
     "icao": "OCN",
     "name": "vOCN",
     "callsign": "Ocean",


### PR DESCRIPTION
Added new virtual airlines to the airlines.json file.

### 🔗 Your VATSIM ID

1274107

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://virtual.austrian.com (for Austrian - AUA)
https://vamsys.io/register/fondue (for Swiss - SWR)

### 📚 Description

Austrian Virtual is an official Virtual Airline being approved by Austrian Airlines. Established in the early 2000s it has been running initially on it's own Website and Tracker before having switched to the state of the art platform vAMSYS. Pilots can enjoy current and historic schedules with its respective airframes.

Swiss is a Virtual Airline operating in the heart of Switzerland. Serving multiple destinations and replicating it's real counterpart with current as well as historic schedules, it caters to a plethora of pilots.

