### PR TITLE
Update airlines.json to add Pan-African VA

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1842,5 +1842,11 @@
     "name": "VIRTUAL LION AIR GROUP",
     "callsign": "MENTARI",
     "virtual": true
+  },
+  {
+    "icao": "PNF",
+    "name": "Pan-African Virtual Airlines"
+    "callsign": "PanAF"
+    "virtual": true
   }
 ]

--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1845,8 +1845,8 @@
   },
   {
     "icao": "PNF",
-    "name": "Pan-African Virtual Airlines"
-    "callsign": "PanAF"
+    "name": "Pan-African Virtual Airlines",
+    "callsign": "PanAF",
     "virtual": true
   }
 ]


### PR DESCRIPTION
Current information in the system for PNF is incorrect. It displays Panafriqiyah as the name and ZEBEC as callsign, which causes confusion. Please correct airline name to Pan-African Virtual Airlines and the callsign to PanAF

### 🔗 Your VATSIM ID
1344759

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [x] ✈️ Airline Changes
- [x] 🆕 New Airline
- [x] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://panafva.com/

### 📚 Description
This request is to correct our VA information to show Pan-African Virtual Airlines as the airline name and PanAF as the call sign. Our ICAO code is PNF and if needed our ITA code is KA. 
Our pilots look forward to be called by our airline name. 
Thanks
Ibra Diack 
Pan-African virtual airlines CEO


