### PR TITLE
Add vAirAsia and its subsidiaries to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1845,55 +1845,55 @@
   },
   {
     "icao": "AXM",
-    "name": "vAirAsia",
+    "name": "vAirAsia.com",
     "callsign": "RED CAP",
     "virtual": true
   },
    {
     "icao": "XAX",
-    "name": "vAirAsia X",
+    "name": "vAirAsia.com",
     "callsign": "XANADU",
     "virtual": true
   },
    {
     "icao": "AIQ",
-    "name": "Thai vAirAia",
+    "name": "vAirAsia.com",
     "callsign": "THAI ASIA",
     "virtual": true
   },
   {
     "icao": "AWQ",
-    "name": "Indonesia vAirAsia",
+    "name": "vAirAsia.com",
     "callsign": "WAGON AIR",
     "virtual": true
   },
   {
     "icao": "APG",
-    "name": "Philippines vAirAsia",
+    "name": "vAirAsia.com",
     "callsign": "COOL RED",
     "virtual": true
   },
    {
     "icao": "TAX",
-    "name": "Thai vAirAsia X",
+    "name": "vAirAsia.com",
     "callsign": "EXPRESS WING",
     "virtual": true
   },
   {
     "icao": "KTC",
-    "name": "vAirAsia Cambodia",
+    "name": "vAirAsia.com",
     "callsign": "RED NAGA",
     "virtual": true
   },
   {
     "icao": "IAD",
-    "name": "vAirAsia India",
+    "name": "vAirAsia.com",
     "callsign": "RED KNIGHT",
     "virtual": true
   },
   {
     "icao": "WAJ",
-    "name": "vAirAsia Japan",
+    "name": "vAirAsia.com",
     "callsign": "WING ASIA",
     "virtual": true
   } 

--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1842,5 +1842,59 @@
     "name": "VIRTUAL LION AIR GROUP",
     "callsign": "MENTARI",
     "virtual": true
-  }
+  },
+  {
+    "icao": "AXM",
+    "name": "vAirAsia",
+    "callsign": "RED CAP",
+    "virtual": true
+  },
+   {
+    "icao": "XAX",
+    "name": "vAirAsia X",
+    "callsign": "XANADU",
+    "virtual": true
+  },
+   {
+    "icao": "AIQ",
+    "name": "Thai vAirAia",
+    "callsign": "THAI ASIA",
+    "virtual": true
+  },
+  {
+    "icao": "AWQ",
+    "name": "Indonesia vAirAsia",
+    "callsign": "WAGON AIR",
+    "virtual": true
+  },
+  {
+    "icao": "APG",
+    "name": "Philippines vAirAsia",
+    "callsign": "COOL RED",
+    "virtual": true
+  },
+   {
+    "icao": "TAX",
+    "name": "Thai vAirAsia X",
+    "callsign": "EXPRESS WING",
+    "virtual": true
+  },
+  {
+    "icao": "KTC",
+    "name": "vAirAsia Cambodia",
+    "callsign": "RED NAGA",
+    "virtual": true
+  },
+  {
+    "icao": "IAD",
+    "name": "vAirAsia India",
+    "callsign": "RED KNIGHT",
+    "virtual": true
+  },
+  {
+    "icao": "WAJ",
+    "name": "vAirAsia Japan",
+    "callsign": "WING ASIA",
+    "virtual": true
+  } 
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1507706

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website
vairasia.com
Please refer your VA Website(s) - ideally, with some proof that you belong to it. 

### 📚 Description
vAirAsia is a virtual airline dedicated to replicating the operations and spirit of the world’s 16-time best low-cost carrier. We provide a platform for flight simulation enthusiasts to fly a comprehensive network of routes across the Asia Pacific region, utilizing a modern fleet and industry-standard dispatching tools to ensure every flight is as realistic as possible. We operate the full AirAsia ecosystem and its subsidiaries, including AirAsia, AirAsia X, Teleport, Thai AirAsia, Indonesia AirAsia, Philippines AirAsia, Thai AirAsia X, and AirAsia Cambodia.
<!-- Tell us more about your PR -->

