### PR TITLE
Add vAirAsia and its subsidiaries to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1842,5 +1842,59 @@
     "name": "VIRTUAL LION AIR GROUP",
     "callsign": "MENTARI",
     "virtual": true
+  },
+  {
+    "icao": "AXM",
+    "name": "vAirAsia",
+    "callsign": "RED CAP",
+    "virtual": true
+  },
+  {
+    "icao": "XAX",
+    "name": "vAirAsia",
+    "callsign": "XANADU",
+    "virtual": true
+  },
+  {
+    "icao": "AIQ",
+    "name": "vAirAsia",
+    "callsign": "THAI ASIA",
+    "virtual": true
+  },
+  {
+    "icao": "AWQ",
+    "name": "vAirAsia",
+    "callsign": "WAGON AIR",
+    "virtual": true
+  },
+  {
+    "icao": "APG",
+    "name": "vAirAsia",
+    "callsign": "COOL RED",
+    "virtual": true
+  },
+   {
+    "icao": "TAX",
+    "name": "vAirAsia",
+    "callsign": "EXPRESS WING",
+    "virtual": true
+  },
+  {
+    "icao": "KTC",
+    "name": "vAirAsia",
+    "callsign": "RED NAGA",
+    "virtual": true
+  },
+  {
+    "icao": "IAD",
+    "name": "vAirAsia",
+    "callsign": "RED KNIGHT",
+    "virtual": true
+  },
+  {
+    "icao": "WAJ",
+    "name": "vAirAsia",
+    "callsign": "WING ASIA",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID
1507706
<!-- Please specify your CID -->

### 🔗 Linked Issue
Duplicate ICAO found for "TAX", TAX is Icao code for Thai AirAsia X.
Please whitelist TAX in validate-json.mjs, thanks!
<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website
vairasia.com
allstarsbooking.vairasia.com
Please refer your VA Website(s) - ideally, with some proof that you belong to it. 

### 📚 Description
vAirAsia is a virtual airline dedicated to replicating the operations and spirit of the world’s 16-time best low-cost carrier. We provide a platform for flight simulation enthusiasts to fly a comprehensive network of routes across the Asia Pacific region, utilizing a modern fleet and industry-standard dispatching tools to ensure every flight is as realistic as possible. We operate the full AirAsia ecosystem and its subsidiaries, including AirAsia, AirAsia X, Teleport, Thai AirAsia, Indonesia AirAsia, Philippines AirAsia, Thai AirAsia X, and AirAsia Cambodia.
<!-- Tell us more about your PR -->

