### PR TITLE
Add Wolfair Aviation to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1842,5 +1842,11 @@
     "name": "VIRTUAL LION AIR GROUP",
     "callsign": "MENTARI",
     "virtual": true
+  },
+  {
+    "icao": "WLF",
+    "name": "Wolfair Aviation",
+    "callsign": "Wolfair",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1687974

### ❓ Type of change

- [x] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://wolfairaviation.com

### 📚 Description

We applied and were approved as a VA on Vatsim. Currently, we use the ICAO "WLF", which is assigned to "Hubei Sky-blue International Aviation Academy Co., Ltd" ("SKY BLUE"). This ICAO is not currently in use on IRL either. We are part of the FSHub network of VA's, and below is the link as well.

https://fshub.io/airline/WLF/overview
