### PR TITLE
Update airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1842,13 +1842,13 @@
     "name": "VIRTUAL LION AIR GROUP",
     "callsign": "MENTARI",
     "virtual": true
-  }
+  },
   {
     "icao": "SGE",
     "name": "SUDWEST VIRTUAL",
     "callsign": "YELLOWDOT",
     "virtual": true
-  }
+  },
   {
     "icao": "HGE",
     "name": "SUDLINE",

--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1843,4 +1843,16 @@
     "callsign": "MENTARI",
     "virtual": true
   }
+  {
+    "icao": "SGE",
+    "name": "SUDWEST VIRTUAL",
+    "callsign": "YELLOWDOT",
+    "virtual": true
+  }
+  {
+    "icao": "HGE",
+    "name": "SUDLINE",
+    "callsign": "HOPSOUTH",
+    "virtual": true
+  }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1680886

### 🔗 Linked Issue

N/A

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

[Discord](https://discord.gg/4pDzmmUY)
[vAMSYS](https://vamsys.io/register/yellow)

### 📚 Description

Adds Callsigns for FlySudwestDE, a german virtual airline.
Adds both its Sudwest (YellowDot) and SUDLine (HopSouth) callsign.


