### PR TITLE
Add ITA Airways virtual (ITY) to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1,5 +1,11 @@
 [
   {
+    "icao": "ITY",
+    "name": "ITA Airways virtual",
+    "callsign": "ITARROW",
+    "virtual": true
+  },
+  {
    "icao": "ASK",
    "name": "AIRSKY",  
    "callsign": "AIRSKY",


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1767830

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://www.ityvirtual.com/
https://vamsys.io/phoenix


### 📚 Description
This PR adds the virtual airline "ITA Airways virtual" to airlines.json.

Details:
- ICAO: ITY
- Callsign: ITARROW
- virtual: true

This update ensures that the VA is correctly represented within the VATSIM Radar data structure and follows the formatting and conventions used throughout the repository
<!-- Tell us more about your PR -->

