### PR TITLE
Add multiple new vAirAsia virtual airlines to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1920,5 +1920,53 @@
     "name": "Express Freighters Australia",
     "callsign": "Express Freight Qantas",
     "virtual": true
+  },
+  {
+    "icao": "AXM",
+    "name": "vAirAsia",
+    "callsign": "RED CAP",
+    "virtual": true
+  },
+  {
+    "icao": "XAX",
+    "name": "vAirAsia",
+    "callsign": "XANADU",
+    "virtual": true
+  },
+  {
+    "icao": "AIQ",
+    "name": "vAirAsia",
+    "callsign": "THAI ASIA",
+    "virtual": true
+  },
+  {
+    "icao": "AWQ",
+    "name": "vAirAsia",
+    "callsign": "WAGON AIR",
+    "virtual": true
+  },
+  {
+    "icao": "APG",
+    "name": "vAirAsia",
+    "callsign": "COOL RED",
+    "virtual": true
+  },
+  {
+    "icao": "KTC",
+    "name": "vAirAsia",
+    "callsign": "RED NAGA",
+    "virtual": true
+  },
+  {
+    "icao": "IAD",
+    "name": "vAirAsia",
+    "callsign": "RED KNIGHT",
+    "virtual": true
+  },
+  {
+    "icao": "WAJ",
+    "name": "vAirAsia",
+    "callsign": "WING ASIA",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1507706

### 🔗 Linked Issue
None

### ❓ Type of change

- [ ] ✈️ Airline Changes
- [X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website
https://vairasia.com/
https://vamsys.io/register/vairasia

### 📚 Description
vAirAsia is a virtual airline dedicated to replicating the operations and spirit of the world’s 16-time best low-cost carrier. We provide a platform for flight simulation enthusiasts to fly a comprehensive network of routes across the Asia Pacific region, utilizing a modern fleet and industry-standard dispatching tools to ensure every flight is as realistic as possible. We operate the full AirAsia ecosystem and its subsidiaries, including AirAsia, AirAsia X, Teleport, Thai AirAsia, Indonesia AirAsia, Philippines AirAsia, Thai AirAsia X, and AirAsia Cambodia.

