### PR TITLE
Add Air China Virtual

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1968,5 +1968,29 @@
     "name": "vAirAsia",
     "callsign": "WING ASIA",
     "virtual": true
+  },
+  {
+    "icao": "CCA",
+    "name": "Air China Virtual",
+    "callsign": "AIR CHINA",
+    "virtual": true
+  },
+  {
+    "icao": "CAO",
+    "name": "Air China Virtual (Cargo)",
+    "callsign": "AIR CHINA FREIGHT",
+    "virtual": true
+  },
+  {
+    "icao": "BJN",
+    "name": "Air China Virtual (Beijing Airlines)",
+    "callsign": "AIR JINGHUA",
+    "virtual": true
+  },
+  {
+    "icao": "CCD",
+    "name": "Air China Virtual (Dalian Airlines)",
+    "callsign": "XIANGJIAN",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1897662

### 🔗 Linked Issue

N/A

### ❓ Type of change

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://airchinavirtual.org/

### 📚 Description

Add Air China Virtual to VATSIM radar, including 4 prefixes operating by Air China Virtual

