### PR TITLE
Add Koala Air to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -2033,4 +2033,5 @@
     "name": "Koala Air",
     "callsign": "KOALA",
     "virtual": false
+  }
 ]

--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -2027,5 +2027,10 @@
     "name": "EgyptAir Virtual",
     "callsign": "EgyptAir",
     "virtual": true
-  }
+  },
+  {
+    "icao": "KOA",
+    "name": "Koala Air",
+    "callsign": "KOALA",
+    "virtual": false
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1729855

### 🔗 Linked Issue

_N/A_

### ❓ Type of change

- [ ] ✈️ Airline Changes
- [x ] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://koalaairvirtual.com/

### 📚 Description

We are a virtual airline, however Koala Air also exists in real life, so I added the callsign as a non-virtual airline so that it shows up as correct for us as well. In the future we can also add the `CS=` flag in our remarks if we want it displayed as virtual. 