### PR TITLE
feat: Add Air Cairo

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -2027,5 +2027,11 @@
     "name": "EgyptAir Virtual",
     "callsign": "EgyptAir",
     "virtual": true
+  },
+  {
+    "icao": "MSC",
+    "name": "Air Cairo Virtual",
+    "callsign": "Air Cairo",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1597166

### 🔗 Linked Issue

none

### ❓ Type of change

Adding Air Cairo as a subsidiary of EgyptAir virtual, it is run on the same platform

- [x] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://egyptair-va.com

### 📚 Description

Air Cairo is a low cost subsidiary of Egypt Air and is server by the same Virtual Airline.

