### PR TITLE
Add FTA320 virtual airline to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -2027,5 +2027,11 @@
     "name": "EgyptAir Virtual",
     "callsign": "EgyptAir",
     "virtual": true
+  },
+   {
+    "icao": "FTA",
+    "name": "FTA320",
+    "callsign": "FLIGHT TRAINING 320",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1741681

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://fta320.es/

### 📚 Description

Add FLIGHT TRAINING 320 VA to VATSIM Radar

