### PR TITLE
Delete Nox Airlines entry

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1225,12 +1225,6 @@
     "virtual": true
   },
   {
-    "icao": "NOX",
-    "name": "Nox Airlines",
-    "callsign": "noxair",
-    "virtual": true
-  },
-  {
     "icao": "HUN",
     "name": "Hungarian Airlines",
     "callsign": "HUNGARIAN",


### PR DESCRIPTION
Removed Nox Airlines entry from airlines.json. As it's no longer used

### 🔗 Your VATSIM ID

1741681

### 🔗 Linked Issue


### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [x] ✈️ Airline Changes
- [ ] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

no longer in use.

### 📚 Description

Delete nox airlines

