### PR TITLE
Modify vBAW EFW callsign and add virtual airline BAT

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1058,7 +1058,13 @@
   {
     "icao": "EFW",
     "name": "vBAW",
-    "callsign": "Euroflyer",
+    "callsign": "Griffin",
+    "virtual": true
+  },
+  {
+    "icao": "BAT",
+    "name": "vBAW",
+    "callsign": "Gherkin",
     "virtual": true
   },
   {


### PR DESCRIPTION
Updated callsign for vBAW and added new virtual airline BAT.

### 🔗 Your VATSIM ID

1317411

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [x] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://www.vbaw.net


