### PR TITLE
Add SteelJet virtual airline

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1068,6 +1068,24 @@
     "virtual": true
   },
   {
+    "icao": "SJC",
+    "name": "SteelJet Cargo",
+    "callsign": "STEELCARGO",
+    "virtual": true
+  },
+  {
+    "icao": "SJL",
+    "name": "SteelJet Logistics",
+    "callsign": "STEELJET",
+    "virtual": true
+  },
+  {
+    "icao": "SJE",
+    "name": "SteelJet Executive",
+    "callsign": "STEELEXECUTIVE",
+    "virtual": true
+  },
+  {
     "icao": "EUF",
     "name": "EuroFly",
     "callsign": "EUROFLY",


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1410399

### 🔗 Linked Issue

None

### ❓ Type of change

- [ ] ✈️ Airline Changes
- [x ] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

Only internal: https://steeljet.up.railway.app/

### 📚 Description

Adds SteelJet virtual airline divisions SJC, SJL, SJE to the list of callsigns.

