### PR TITLE
Add Eagle Airways Virtual to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -6,6 +6,12 @@
     "virtual": true
   },
   {
+    "icao": "EGV",
+    "name": "Eagle Airways Virtual",
+    "callsign": "SKYRISE",
+    "virtual": true
+  },
+  {
     "icao": "OCN",
     "name": "vOCN",
     "callsign": "Ocean",


### PR DESCRIPTION
Added new virtual airline 'Eagle Airways Virtual' with ICAO 'EGV' and callsign 'SKYRISE' to the airlines.json file.

### 🔗 Your VATSIM ID

1977707

### 🔗 Linked Issue


### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://eagle-airways.jimdosite.com Eagle Airways Virtual official website

### 📚 Description

Eagle Airways Virtual - A virtual airline based in London Gatwick flying routes from all arround the world. We operate Passenger and Cargo aircraft, from the A320s to the B777s.

