### PR TITLE
ADD AIRBORNEO(BNE) to airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -2058,5 +2058,12 @@
     "name": "Koala Air",
     "callsign": "KOALA",
     "virtual": false
+
   }
-]
+   {
+    "icao": "BNE",
+    "name": "AirBorneo",
+    "callsign": "Borneo",
+    "virtual": false
+
+


### PR DESCRIPTION
 🔗 Your VATSIM ID

  1856134

### 🔗 Linked Issue

https://www.planespotters.net/airline/AirBorneo


### ❓ Type of change
- [ ] ✈️ Airline Changes
- [YES ] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

Please refer your VA Website(s) - ideally, with some proof that you belong to it. 

### 📚 Description

Airborneo is airline That establish 2026 Actually before it take over BY sarawak it was a Maswing and  after new transition it be given new Name AIrborneo now the Airborneo serving b737 and new Callsign Borneo

