### PR TITLE
Update to airlines.json file to add Metro Air Virtual to the Airlines…

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -2058,5 +2058,11 @@
     "name": "Koala Air",
     "callsign": "KOALA",
     "virtual": false
+  },
+  {
+    "icao": "MET",
+    "name": "Metro Air Virtual",
+    "callsign": "METRO",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
… list.

### 🔗 Your VATSIM ID

1220594

Metro Air Virtual missing from Airline list

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website
www.metroairvirtual.com
My profile - https://metroairvirtual.com/pilots/MET1524

### 📚 Description
Adding Metro Air Virtual to the Callsign List

