### PR TITLE
Update airlines.json - Add Mercargo Virtual

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -2058,5 +2058,11 @@
     "name": "Koala Air",
     "callsign": "KOALA",
     "virtual": false
+  },
+  {
+    "icao": "MRK",
+    "name": "Mercargo Virtual",
+    "callsign": "MERCARGO",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
Add Mercargo Virtual - https://mercargova.com/

### 🔗 Your VATSIM ID

1259956

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

[https://mercargova.com/](https://mercargova.com/)

### 📚 Description

<!-- Tell us more about your PR -->

Virtual Airline based in South America, Argentina & Uruguay, founded by ex members of an older virtual cargo airline. Mercargo does cargo scheduled and charter flights within the VATSIM network, looking to achieve an airline partnership in VATSIM.