### PR TITLE
Add Kuwait Airways Virtual

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -2058,5 +2058,11 @@
     "name": "Koala Air",
     "callsign": "KOALA",
     "virtual": false
-  }
-]
+  },
+  {
+    "icao": "KAC",
+    "name": "Kuwait Airways Virtual",
+    "callsign": "KUWAITI",
+    "virtual": true
+  },
+


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1984442

### 🔗 Linked Issue

### ❓ Type of change

- [ ] ✈️ Airline Changes
- [x] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website
https://vamsys.io/register/kuwaitairways 

### 📚 Description

Adding Kuwait Airways Virtual (KAC) as a new virtual airline entry.

