### PR TITLE
Update airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1,4 +1,9 @@
-[
+[},
+  {
+    "icao": "FFP",
+    "name": "FISCHER Air",
+    "callsign": "Flying Fisch",
+    "virtual": true
   {
     "icao": "ASK",
     "name": "AIRSKY",


### PR DESCRIPTION
We would kindly like to request an update to our VATSIM Radar entry, specifically regarding our ICAO/callsign mapping.

Fischer Air was a real airline operating in the early 2000s. In addition, our community operated a virtual version of Fischer Air on VATSIM between 2006 and 2014, using the ICAO code FFP and the callsign Flying Fish.

We are currently relaunching our virtual airline and would like to continue using the same historical identity. Unfortunately, VATSIM Radar is currently displaying our flights under a different callsign, which does not reflect our registered VATSIM flight plan.

We would greatly appreciate it if you could update the mapping so that:

ICAO: FFP
Airline Name: Fischer Air
Callsign: Flying Fish

Thank you very much for your time and support. We truly appreciate your help in preserving the historical identity of our virtual airline.

### 🔗 Your VATSIM ID

<!-- Please specify your CID -->

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [ ] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

Please refer your VA Website(s) - ideally, with some proof that you belong to it. 

### 📚 Description

<!-- Tell us more about your PR -->

