### PR TITLE
added AeroColombia virtual airline

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -2059,4 +2059,10 @@
     "callsign": "KOALA",
     "virtual": false
   }
+  {
+    "icao": "XCO",
+    "name": "AeroColombia",
+    "callsign": "AEROCOLOMBIA",
+    "virtual": true
+  }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1705570

### 🔗 Linked Issue

1705570

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [ X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://aerocolombia.com.co/

### 📚 Description

AeroColombia is a new virtual airline, based on Colombia. Hub are: SKBO
