### PR TITLE
added AeroColombia virtual airline

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -2058,5 +2058,11 @@
     "name": "Koala Air",
     "callsign": "KOALA",
     "virtual": false
+  },
+  {
+    "icao": "XCO",
+    "name": "AeroColombia",
+    "callsign": "AeroColombia",
+    "virtual": true
   }
 ]


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1705570

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] ✈️ Airline Changes
- [ X] 🆕 New Airline
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 VA Website

https://aerocolombia.com.co/

### 📚 Description

AeroColombia is a new virtual airline, based on Colombia. Hub are: SKBO

