### PR TITLE
Update airlines.json

### DIFF
--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1,4 +1,8 @@
-[
+{
+    "icao": "FFP",
+    "name": "FISCHER Air",
+    "callsign": "Flying Fisch",
+    "virtual": true
   {
     "icao": "ASK",
     "name": "AIRSKY",

--- a/custom-data/airlines.json
+++ b/custom-data/airlines.json
@@ -1,8 +1,9 @@
 {
     "icao": "FFP",
-    "name": "FISCHER Air",
+    "name": "Fischer Air",
     "callsign": "Flying Fisch",
     "virtual": true
+ },
   {
     "icao": "ASK",
     "name": "AIRSKY",


### PR DESCRIPTION
Dear VATSIM Radar Team,

We would kindly like to request an update to our VATSIM Radar entry, specifically regarding the ICAO/callsign mapping for our virtual airline.

Fischer Air was a real Polish airline operating in the early 2000s. In addition, our community operated a virtual version of Fischer Air on VATSIM between 2006 and 2014, using the historical ICAO code FFP and callsign Flying Fish.

We are currently relaunching our virtual airline and would like to continue using this historical identity.

Unfortunately, VATSIM Radar is currently displaying our flights under a different callsign, which does not correspond to our registered VATSIM flight plan.

We would therefore greatly appreciate it if you could update the mapping as follows:

Airline Name: Fischer Air
ICAO: FFP
Callsign: Flying Fish
Vatsim ID: 967522
Web: https://flylat.net/dashboard/company/company_profile.php?airline=103948

We would also like the VATSIM Radar entry to recognize our virtual airline correctly when using the appropriate RMK/CS information in our flight plans.

Thank you very much for your time and support. We truly appreciate your help in preserving the historical identity of Fischer Air and our virtual airline community.

Kind regards,
Fischer Air Virtual Airline
